### PR TITLE
Fixed issue: Expected linebreaks to be 'LF' but found 'CRLF' in windows

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,7 +37,7 @@
     "jsx-a11y/click-events-have-key-events": "off",
     "jsx-a11y/no-noninteractive-element-interactions": "off",
     "jsx-a11y/no-static-element-interactions": "off",
-    "linebreak-style": ["error", "windows"],
+    "linebreak-style": "off",
     "max-len": "off",
     "new-cap": "off",
     "no-case-declarations": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,6 +37,7 @@
     "jsx-a11y/click-events-have-key-events": "off",
     "jsx-a11y/no-noninteractive-element-interactions": "off",
     "jsx-a11y/no-static-element-interactions": "off",
+    "linebreak-style": ["error", "windows"],
     "max-len": "off",
     "new-cap": "off",
     "no-case-declarations": "off",


### PR DESCRIPTION
Added a rule in .eslintrc.json to fix below issue in windows
![issue](https://github.com/user-attachments/assets/50382c4b-a666-41d5-a32a-396f4ab9dd79)
