### PR TITLE
fix: now node is set to correct versions

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Install ESLint
         run: npm install eslint@8.10.0 @microsoft/eslint-formatter-sarif@2.1.7


### PR DESCRIPTION
 This is to avoid ESLint warnings through github actions.

This is in continuity of issue #44 .